### PR TITLE
Update for newer ruby method name changes

### DIFF
--- a/lib/dm-types/support/dirty_minder.rb
+++ b/lib/dm-types/support/dirty_minder.rb
@@ -83,7 +83,7 @@ module DataMapper
             delete_at replace fill clear
             slice! reverse! rotate! compact! flatten! uniq!
             collect! map! sort! sort_by! reject! delete_if!
-            select! shuffle!
+            delete_if select! shuffle!
           }.select { |meth| ::Array.instance_methods.any? { |m| m.to_s == meth } },
 
           ::Hash => %w{


### PR DESCRIPTION
Ruby 2.6 (and god knows what other versions)  changed `Array#delete_if!` to `Array#delete_if`.  Consequently if you used `#delete_if` on a Json property, it wouldn't trigger as dirty.